### PR TITLE
Use evm_mine `timestamp` parameter

### DIFF
--- a/test/claim.test.ts
+++ b/test/claim.test.ts
@@ -94,8 +94,8 @@ describe('StakingPool.claim', () => {
           firstRoundInit.duration
         );
       await testEnv.stakingAsset.connect(alice).faucet();
-      const tx = await testEnv.stakingAsset.connect(alice).approve(testEnv.stakingPool.address, RAY);
-      await advanceTimeTo(await getTimestamp(tx), firstRoundStartTimestamp);
+      await testEnv.stakingAsset.connect(alice).approve(testEnv.stakingPool.address, RAY);
+      await advanceTimeTo(firstRoundStartTimestamp);
     });
 
     it('reverts if user reward is 0', async () => {
@@ -143,29 +143,29 @@ describe('StakingPool.claim', () => {
           firstRoundInit.duration
         );
       await testEnv.stakingAsset.connect(alice).faucet();
-      const tx = await testEnv.stakingAsset.connect(alice).approve(testEnv.stakingPool.address, RAY);
-      await advanceTimeTo(await getTimestamp(tx), firstRoundStartTimestamp);
+      await testEnv.stakingAsset.connect(alice).approve(testEnv.stakingPool.address, RAY);
+      await advanceTimeTo(firstRoundStartTimestamp);
       await testEnv.stakingPool.connect(alice).stake(amount);
     });
 
     context('the pool is closed', async () => {
       it('alice claim reward', async () => {
-        const tx = await testEnv.stakingPool.connect(deployer).closePool();
-        await advanceTimeTo(await getTimestamp(tx), secondRoundStartTimestamp);
-  
+        await testEnv.stakingPool.connect(deployer).closePool();
+        await advanceTimeTo(secondRoundStartTimestamp);
+
         const poolDataBefore = await getPoolData(testEnv);
         const userDataBefore = await getUserData(testEnv, alice);
         const claimTx = await testEnv.stakingPool.connect(alice).claim();
-  
+
         const [expectedPoolData, expectedUserData] = expectDataAfterClaim(
           poolDataBefore,
           userDataBefore,
           await getTimestamp(claimTx)
         );
-  
+
         const poolDataAfter = await getPoolData(testEnv);
         const userDataAfter = await getUserData(testEnv, alice);
-  
+
         expect(poolDataAfter).to.be.equalPoolData(expectedPoolData);
         expect(userDataAfter).to.be.equalUserData(expectedUserData);
       });
@@ -174,19 +174,19 @@ describe('StakingPool.claim', () => {
         await testEnv.stakingPool.connect(deployer).closePool();
         const poolDataBefore = await getPoolData(testEnv);
         const userDataBefore = await getUserData(testEnv, alice);
-  
+
         const claimTx = await testEnv.stakingPool.connect(alice).claim();
-        await advanceTimeTo(await getTimestamp(claimTx), thirdRoundStartTimestamp);
-  
+        await advanceTimeTo(thirdRoundStartTimestamp);
+
         const [expectedPoolData, expectedUserData] = expectDataAfterClaim(
           poolDataBefore,
           userDataBefore,
           await getTimestamp(claimTx)
         );
-  
+
         const poolDataAfter = await getPoolData(testEnv);
         const userDataAfter = await getUserData(testEnv, alice);
-  
+
         expect(poolDataAfter).to.be.equalPoolData(expectedPoolData);
         expect(userDataAfter).to.be.equalUserData(expectedUserData);
       });
@@ -195,12 +195,12 @@ describe('StakingPool.claim', () => {
         await testEnv.stakingPool.connect(deployer).closePool();
         const poolDataBefore = await getPoolData(testEnv);
         const userDataBefore = await getUserData(testEnv, alice);
-  
+
         await advanceTime(10);
-  
+
         const poolDataAfter = await getPoolData(testEnv);
         const userDataAfter = await getUserData(testEnv, alice);
-  
+
         expect(poolDataAfter).to.eql(poolDataBefore);
         expect(userDataAfter).to.eql(userDataBefore);
       });

--- a/test/stake.test.ts
+++ b/test/stake.test.ts
@@ -66,10 +66,10 @@ describe('StakingPool.stake', () => {
 
     context('Time passes', async () => {
       beforeEach('init the pool', async () => {
-        const tx = await testEnv.stakingAsset
+        await testEnv.stakingAsset
           .connect(alice)
           .approve(testEnv.stakingPool.address, RAY);
-        await advanceTimeTo(await getTimestamp(tx), startTimestamp);
+        await advanceTimeTo(startTimestamp);
       });
 
       it('reverts if user staking amount is 0', async () => {
@@ -101,10 +101,10 @@ describe('StakingPool.stake', () => {
 
       context('pool is closed', async () => {
         beforeEach('time passes and pool is closed', async () => {
-          const tx = await testEnv.stakingPool.connect(alice).stake(stakeAmount);
-          await advanceTimeTo(await getTimestamp(tx), endTimestamp);
+          await testEnv.stakingPool.connect(alice).stake(stakeAmount);
+          await advanceTimeTo(endTimestamp);
         })
-        
+
         it('revert if general account close the pool', async () => {
           await expect(testEnv.stakingPool.connect(alice).closePool()
           ).to.be.revertedWith('OnlyAdmin');
@@ -143,8 +143,8 @@ describe('StakingPool.stake', () => {
       await testEnv.stakingAsset.connect(alice).approve(testEnv.stakingPool.address, RAY);
       await testEnv.stakingAsset.connect(bob).faucet();
 
-      const tx = await testEnv.stakingAsset.connect(bob).approve(testEnv.stakingPool.address, RAY);
-      await advanceTimeTo(await getTimestamp(tx), startTimestamp);
+      await testEnv.stakingAsset.connect(bob).approve(testEnv.stakingPool.address, RAY);
+      await advanceTimeTo(startTimestamp);
     });
 
     it('first stake and second stake from alice', async () => {

--- a/test/token.test.ts
+++ b/test/token.test.ts
@@ -30,7 +30,7 @@ describe('StakingPool.token', () => {
   async function fixture() {
     const testEnv = await setTestEnv();
     await testEnv.rewardAsset.connect(deployer).faucet();
-      await testEnv.rewardAsset.connect(deployer).approve(testEnv.stakingPool.address, RAY);
+    await testEnv.rewardAsset.connect(deployer).approve(testEnv.stakingPool.address, RAY);
     await testEnv.stakingPool
       .connect(deployer)
       .initNewPool(rewardPersecond, startTimestamp, duration);
@@ -52,10 +52,10 @@ describe('StakingPool.token', () => {
   context('ERC20', async () => {
     beforeEach('deploy staking pool', async () => {
       await testEnv.stakingAsset.connect(alice).faucet();
-      const tx = await testEnv.stakingAsset
+      await testEnv.stakingAsset
         .connect(alice)
         .approve(testEnv.stakingPool.address, RAY);
-      await advanceTimeTo(await getTimestamp(tx), startTimestamp);
+      await advanceTimeTo(startTimestamp);
     });
 
     it('ERC20 functions are unavailable', async () => {
@@ -86,10 +86,10 @@ describe('StakingPool.token', () => {
   context('ERC20Wrapper', async () => {
     beforeEach('deploy staking pool', async () => {
       await testEnv.stakingAsset.connect(alice).faucet();
-      const tx = await testEnv.stakingAsset
+      await testEnv.stakingAsset
         .connect(alice)
         .approve(testEnv.stakingPool.address, RAY);
-      await advanceTimeTo(await getTimestamp(tx), startTimestamp);
+      await advanceTimeTo(startTimestamp);
     });
 
     it('wrapper tokens are minted in staking', async () => {
@@ -116,10 +116,10 @@ describe('StakingPool.token', () => {
   context('ERC20Votes', async () => {
     beforeEach('time passes', async () => {
       await testEnv.stakingAsset.connect(alice).faucet();
-      const tx = await testEnv.stakingAsset
+      await testEnv.stakingAsset
         .connect(alice)
         .approve(testEnv.stakingPool.address, RAY);
-      await advanceTimeTo(await getTimestamp(tx), startTimestamp);
+      await advanceTimeTo(startTimestamp);
       await testEnv.stakingPool.connect(alice).stake(utils.parseEther('100'));
     });
 
@@ -173,8 +173,8 @@ describe('StakingPool.token', () => {
       await testEnv.stakingAsset.connect(alice).faucet();
       await testEnv.stakingAsset.connect(alice).approve(testEnv.stakingPool.address, RAY);
       await testEnv.stakingAsset.connect(bob).faucet();
-      const tx = await testEnv.stakingAsset.connect(bob).approve(testEnv.stakingPool.address, RAY);
-      await advanceTimeTo(await getTimestamp(tx), startTimestamp);
+      await testEnv.stakingAsset.connect(bob).approve(testEnv.stakingPool.address, RAY);
+      await advanceTimeTo(startTimestamp);
     });
   });
 });

--- a/test/utils/time.ts
+++ b/test/utils/time.ts
@@ -32,7 +32,7 @@ export function toTimestamp(
 export function roundStartTimestamp(roundData: InitRoundData) {
   return BigNumber.from(
     Date.UTC(roundData.year, roundData.month - 1, roundData.day, roundData.hour, roundData.minute) /
-      1000
+    1000
   );
 }
 
@@ -45,10 +45,9 @@ export async function advanceTime(secondsToIncrease: number) {
   return await waffle.provider.send('evm_mine', []);
 }
 
-export async function advanceTimeTo(current: BigNumber, target: BigNumber) {
-  const secondsToIncrease = target.sub(current).toNumber();
-  await waffle.provider.send('evm_increaseTime', [secondsToIncrease]);
-  return await waffle.provider.send('evm_mine', []);
+export async function advanceTimeTo(targetInput: BigNumber | number) {
+  const target = (targetInput instanceof BigNumber) ? targetInput.toNumber() : targetInput;
+  return await waffle.provider.send('evm_mine', [target]);
 }
 
 export async function advanceBlockTo(to: number) {

--- a/test/withdraw.test.ts
+++ b/test/withdraw.test.ts
@@ -92,19 +92,19 @@ describe('StakingPool.withdraw', () => {
     context('stake and withdraw scenario', async () => {
       const stakeAmount = utils.parseEther('1');
 
-      beforeEach('time passes and alice stakes', async () => {  
-        const tx = await testEnv.stakingAsset
+      beforeEach('time passes and alice stakes', async () => {
+        await testEnv.stakingAsset
           .connect(alice)
           .approve(testEnv.stakingPool.address, RAY);
 
-        await advanceTimeTo(await getTimestamp(tx), startTimestamp);
+        await advanceTimeTo(startTimestamp);
         await testEnv.stakingPool.connect(alice).stake(stakeAmount);
       });
 
       it('alice withdraws all', async () => {
         const poolDataBefore = await getPoolData(testEnv);
         const userDataBefore = await getUserData(testEnv, alice);
-      
+
         const withdrawTx = await testEnv.stakingPool
           .connect(alice)
           .withdraw(stakeAmount);
@@ -199,38 +199,38 @@ describe('StakingPool.withdraw', () => {
 
     context('withdraw after pool is closed', async () => {
       beforeEach('owner close pool', async () => {
-        const tx = await testEnv.stakingAsset.connect(alice).approve(testEnv.stakingPool.address, RAY);
-        await advanceTimeTo(await getTimestamp(tx), startTimestamp);
-  
+        await testEnv.stakingAsset.connect(alice).approve(testEnv.stakingPool.address, RAY);
+        await advanceTimeTo(startTimestamp);
+
         await testEnv.stakingPool.connect(alice).stake(amount.mul(2));
-        const closeTx = await testEnv.stakingPool.connect(deployer).closePool();
-        await advanceTimeTo(await getTimestamp(closeTx), secondTimestamp);
+        await testEnv.stakingPool.connect(deployer).closePool();
+        await advanceTimeTo(secondTimestamp);
       })
-  
+
       it('reverts if withdraws amount exceeds principal', async () => {
         await expect(
           testEnv.stakingPool.connect(alice).withdraw(amount.mul(3))
         ).to.be.revertedWith('NotEnoughPrincipal');
       });
-  
+
       it('alice withdraws all', async () => {
         const poolDataBefore = await getPoolData(testEnv);
         const userDataBefore = await getUserData(testEnv, alice);
-      
+
         const withdrawTx = await testEnv.stakingPool
           .connect(alice)
           .withdraw(amount.mul(2));
-  
+
         const [expectedPoolData, expectedUserData] = expectDataAfterWithdraw(
           poolDataBefore,
           userDataBefore,
           await getTimestamp(withdrawTx),
           amount.mul(2)
         );
-  
+
         const poolDataAfter = await getPoolData(testEnv);
         const userDataAfter = await getUserData(testEnv, alice);
-  
+
         expect(poolDataAfter).to.be.equalPoolData(expectedPoolData);
         expect(userDataAfter).to.be.equalUserData(expectedUserData);
       });
@@ -241,26 +241,26 @@ describe('StakingPool.withdraw', () => {
         await expect(testEnv.stakingPool.connect(alice).stake(amount)
         ).to.be.revertedWith('Closed');
       });
-  
-  
+
+
       it('alice withdraws partial', async () => {
         const poolDataBefore = await getPoolData(testEnv);
         const userDataBefore = await getUserData(testEnv, alice);
-      
+
         const withdrawTx = await testEnv.stakingPool
           .connect(alice)
           .withdraw(amount);
-  
+
         const [expectedPoolData, expectedUserData] = expectDataAfterWithdraw(
           poolDataBefore,
           userDataBefore,
           await getTimestamp(withdrawTx),
           amount
         );
-  
+
         const poolDataAfter = await getPoolData(testEnv);
         const userDataAfter = await getUserData(testEnv, alice);
-  
+
         expect(poolDataAfter).to.be.equalPoolData(expectedPoolData);
         expect(userDataAfter).to.be.equalUserData(expectedUserData);
       });


### PR DESCRIPTION
### Description
Reduce 2 RPC calls to 1 in `advanceTimeTo` test helper.
`evm_mine` in ganache and hardhat network accepts `timestamp` parameter to exactly mine a block at the given timestamp.

### Reference
https://github.com/trufflesuite/ganache/pull/13/files
https://hardhat.org/hardhat-network/reference/#evm-mine