### PR TITLE
Add a function setEmergency & Modify retrieveResidue when rewardAsset != stakingAsset

### DIFF
--- a/contracts/StakingPoolV2.sol
+++ b/contracts/StakingPoolV2.sol
@@ -173,6 +173,9 @@ contract StakingPoolV2 is IStakingPoolV2, StakedElyfiToken, Ownable {
     SafeERC20.safeTransfer(rewardAsset, user, reward);
 
     uint256 rewardLeft = rewardAsset.balanceOf(address(this));
+    if (rewardAsset == stakingAsset) {
+      rewardLeft -= _poolData.totalPrincipal;
+    }
 
     emit Claim(user, reward, rewardLeft);
   }

--- a/contracts/StakingPoolV2.sol
+++ b/contracts/StakingPoolV2.sol
@@ -217,7 +217,15 @@ contract StakingPoolV2 is IStakingPoolV2, StakedElyfiToken, Ownable {
   }
 
   function retrieveResidue() external onlyOwner {
-    SafeERC20.safeTransfer(rewardAsset, _msgSender(), rewardAsset.balanceOf(address(this)));
+    uint256 residueAmount;
+
+    if (stakingAsset == rewardAsset) {
+      residueAmount = rewardAsset.balanceOf(address(this)) - _poolData.totalPrincipal;
+    } else {
+      residueAmount = rewardAsset.balanceOf(address(this));
+    }
+
+    SafeERC20.safeTransfer(rewardAsset, _msgSender(), residueAmount);
   }
 
   function setEmergency(bool stop) external onlyOwner {

--- a/contracts/StakingPoolV2.sol
+++ b/contracts/StakingPoolV2.sol
@@ -22,6 +22,7 @@ contract StakingPoolV2 is IStakingPoolV2, StakedElyfiToken, Ownable {
   }
 
   struct PoolData {
+    uint256 duration;
     uint256 rewardPerSecond;
     uint256 rewardIndex;
     uint256 startTimestamp;
@@ -33,8 +34,10 @@ contract StakingPoolV2 is IStakingPoolV2, StakedElyfiToken, Ownable {
     mapping(address => uint256) userPrincipal;
     bool isOpened;
     bool isFinished;
-  }
+  } 
 
+  bool internal emergencyStop = false;
+  address internal _admin;
   IERC20 public stakingAsset;
   IERC20 public rewardAsset;
   PoolData internal _poolData;
@@ -159,6 +162,7 @@ contract StakingPoolV2 is IStakingPoolV2, StakedElyfiToken, Ownable {
   }
 
   function _claim(address user) internal {
+    if(emergencyStop == true) revert Emergency();
     uint256 reward = _poolData.getUserReward(user);
 
     if (reward == 0) revert ZeroReward();
@@ -216,11 +220,14 @@ contract StakingPoolV2 is IStakingPoolV2, StakedElyfiToken, Ownable {
     SafeERC20.safeTransfer(rewardAsset, _msgSender(), rewardAsset.balanceOf(address(this)));
   }
 
+  function setEmergency(bool stop) external onlyOwner {
+    emergencyStop = stop;
+  } 
+
   /***************** Modifier ******************/
 
   modifier stakingInitiated() {
     if (_poolData.startTimestamp == 0) revert StakingNotInitiated();
     _;
   }
-
 }

--- a/contracts/interface/IStakingPoolV2.sol
+++ b/contracts/interface/IStakingPoolV2.sol
@@ -10,6 +10,7 @@ interface IStakingPoolV2 {
   error ZeroPrincipal();
   error Finished();
   error Closed();
+  error Emergency();
 
   event Stake(
     address indexed user,

--- a/test/claim.test.ts
+++ b/test/claim.test.ts
@@ -264,4 +264,29 @@ describe('StakingPool.claim', () => {
       expect(userDataAfterClaim).to.be.equalUserData(expectedUserDataClaim);
     });
   });
+
+  context('in case of emergency', async () => {
+    beforeEach('init the pool and alice stakes', async () => {
+      await testEnv.rewardAsset.connect(deployer).faucet();
+      await testEnv.rewardAsset.connect(deployer).approve(testEnv.stakingPool.address, RAY);
+      await testEnv.stakingPool
+        .connect(deployer)
+        .initNewPool(
+          rewardPersecond,
+          firstRoundStartTimestamp,
+          duration
+        );
+      await testEnv.stakingAsset.connect(alice).faucet();
+      await testEnv.stakingAsset.connect(alice).approve(testEnv.stakingPool.address, RAY);
+      await advanceTimeTo(firstRoundStartTimestamp);
+      await testEnv.stakingPool.connect(alice).stake(amount);
+    });
+
+    it('revert if alice claims in an emergency', async () => {
+      await testEnv.stakingPool.connect(deployer).setEmergency(true);
+      await expect(
+        testEnv.stakingPool.connect(alice).claim()
+      ).to.be.revertedWith('Emergency');
+    });
+  });
 });

--- a/test/retrieveResidue.test.ts
+++ b/test/retrieveResidue.test.ts
@@ -1,0 +1,86 @@
+import { BigNumber, utils } from 'ethers';
+import { waffle, ethers } from 'hardhat';
+import { expect } from 'chai';
+
+import { MAX_UINT_AMOUNT, SECONDSPERDAY } from './utils/constants';
+import { advanceTimeTo, toTimestamp, getTimestamp } from './utils/time';
+import { setERC20Metadata } from './utils/testEnv';
+import { StakingAsset, StakingPoolV2 } from '../typechain';
+
+const { loadFixture } = waffle;
+
+require('./utils/matchers.ts');
+
+describe('StakingPool.retrieveResidue', () => {
+  // Note! the reward and the staking asset are the same.
+  // In testEnv, the rewardAsset and stakingAsset of the staking pool are different.
+  let asset: StakingAsset;
+  let stakingPool: StakingPoolV2
+
+  const provider = waffle.provider;
+  const [deployer, depositor] = provider.getWallets();
+
+  const rewardPerSecond = BigNumber.from(utils.parseEther('1'));
+  const year = BigNumber.from(2022);
+  const month = BigNumber.from(7);
+  const day = BigNumber.from(7);
+  const duration = BigNumber.from(1).mul(SECONDSPERDAY);
+
+  const startTimestamp = toTimestamp(year, month, day, BigNumber.from(10));
+  // const endTimestamp = startTimestamp.add(duration);
+
+  before(async () => {
+    const erc20MetadataLibrary = await setERC20Metadata();
+    const stakingAssetFactory = await ethers.getContractFactory('StakingAsset');
+    const elysiaToken = await stakingAssetFactory.deploy('Elysia', 'EL') as StakingAsset;
+    const stakingPoolFactory = await ethers.getContractFactory(
+      'StakingPoolV2',
+      {
+        libraries: {
+          ERC20Metadata: erc20MetadataLibrary.address
+        }
+      }
+    );
+
+    stakingPool = await stakingPoolFactory.deploy(
+      elysiaToken.address,
+      elysiaToken.address,
+    ) as StakingPoolV2;
+    asset = elysiaToken;
+  });
+
+  describe('retrieveResidue', async () => {
+    it('reverts if general account call', async () => {
+      await expect(stakingPool.connect(depositor).retrieveResidue()).to.be.revertedWith(
+        'Ownable: caller is not the owner'
+      );
+    });
+
+    it('should retrieve the asset as much as the reward amount', async () => {
+      // The pool is initialized but has not started yet.
+      await asset.connect(deployer).approve(stakingPool.address, MAX_UINT_AMOUNT);
+      await asset.connect(deployer).faucet();
+
+      // This also sends the reward asset which amounts to rewardPerSecond * duration 
+      const initNewPoolTx = await stakingPool
+        .connect(deployer)
+        .initNewPool(rewardPerSecond, startTimestamp, duration);
+
+      const stakeAmount = BigNumber.from(utils.parseEther('100'));
+
+      // The staking starts
+      await advanceTimeTo(startTimestamp);
+
+      // deployer stakes
+      await stakingPool.connect(deployer).stake(stakeAmount);
+      const poolBalance = await asset.balanceOf(stakingPool.address);
+
+      const tx = await stakingPool.connect(deployer).retrieveResidue();
+      const rewardAmount = poolBalance.sub(stakeAmount)
+
+      await expect(tx)
+        .to.emit(asset, 'Transfer')
+        .withArgs(stakingPool.address, deployer.address, rewardAmount);
+    });
+  });
+});

--- a/test/settings.test.ts
+++ b/test/settings.test.ts
@@ -87,7 +87,7 @@ describe('StakingPool.settings', () => {
 
     it('success', async () => {
       const tx = await testEnv.stakingPool.connect(deployer).retrieveResidue();
-      expect(tx)
+      await expect(tx)
         .to.emit(testEnv.rewardAsset, 'Transfer')
         .withArgs(testEnv.stakingPool.address, deployer.address, RAY);
     });

--- a/test/settings.test.ts
+++ b/test/settings.test.ts
@@ -1,4 +1,4 @@
-import { BigNumber, utils } from 'ethers';
+import { BigNumber, ethers, utils } from 'ethers';
 import { waffle } from 'hardhat';
 import { expect } from 'chai';
 
@@ -107,3 +107,4 @@ describe('StakingPool.settings', () => {
     })
   })
 });
+

--- a/test/withdraw.test.ts
+++ b/test/withdraw.test.ts
@@ -208,7 +208,6 @@ describe('StakingPool.withdraw', () => {
           await getTimestamp(withdrawTx),
           amount.mul(2)
         );
-
         const poolDataAfter = await getPoolData(testEnv);
         const userDataAfter = await getUserData(testEnv, alice);
 
@@ -362,6 +361,47 @@ describe('StakingPool.withdraw', () => {
 
         expect(poolDataAfterWithdraw).eql(expectedPoolDataWithdraw);
         expect(userDataAfterWithdraw).eql(expectedUserDataWithdraw);
+      });
+    });
+
+    context('in case of emergency', async () => {
+      beforeEach('init the pool and alice stakes', async () => {
+        await testEnv.rewardAsset.connect(deployer).faucet();
+        await testEnv.rewardAsset.connect(deployer).approve(testEnv.stakingPool.address, RAY);
+        await testEnv.stakingPool
+          .connect(deployer)
+          .initNewPool(
+            rewardPersecond,
+            firstTimestamp,
+            duration
+          );
+        await testEnv.stakingAsset.connect(alice).faucet();
+        const tx = await testEnv.stakingAsset.connect(alice).approve(testEnv.stakingPool.address, RAY);
+        await advanceTimeTo(firstTimestamp);
+        await testEnv.stakingPool.connect(alice).stake(amount);
+      });
+
+      it('sucess if alice withdraws in an emergency', async () => {
+        await testEnv.stakingPool.connect(deployer).setEmergency(true);
+
+        const poolDataBefore = await getPoolData(testEnv);
+        const userDataBefore = await getUserData(testEnv, alice);
+
+        const withdrawTx = await testEnv.stakingPool
+          .connect(alice)
+          .withdraw(amount);
+
+        const [expectedPoolData, expectedUserData] = expectDataAfterWithdraw(
+          poolDataBefore,
+          userDataBefore,
+          await getTimestamp(withdrawTx),
+          amount
+        );
+        const poolDataAfter = await getPoolData(testEnv);
+        const userDataAfter = await getUserData(testEnv, alice);
+
+        expect(poolDataAfter).to.eql(expectedPoolData);
+        expect(userDataAfter).to.eql(expectedUserData);
       });
     });
   });


### PR DESCRIPTION
I rebased the `feature/set-emergency` branch to main. It is the same content with #15.

Description
- When `emergencyStop` is true, users cannot claim the reward.
- Modify retrieveResidue to handle both case: rewardAsset != stakingAsset, and rewardAsset == stakingAsset.