### PR TITLE
Feature: Add a `manager` role who can extend a pool

### DIFF
--- a/contracts/StakingPoolV2.sol
+++ b/contracts/StakingPoolV2.sol
@@ -21,7 +21,7 @@ contract StakingPoolV2 is IStakingPoolV2, StakedElyfiToken, Ownable, AccessContr
     stakingAsset = stakingAsset_;
     rewardAsset = rewardAsset_;
     _admin = msg.sender;
-    _setupRole(MANAGER_ROLE, msg.sender);
+    _setupRole(DEFAULT_ADMIN_ROLE, msg.sender);
   }
 
   struct PoolData {
@@ -40,7 +40,6 @@ contract StakingPoolV2 is IStakingPoolV2, StakedElyfiToken, Ownable, AccessContr
   } 
 
   bool internal emergencyStop = false;
-  bytes32 public constant MANAGER_ROLE = keccak256("MANAGER_ROLE");
   address internal _admin;
   IERC20 public stakingAsset;
   IERC20 public rewardAsset;
@@ -211,9 +210,11 @@ contract StakingPoolV2 is IStakingPoolV2, StakedElyfiToken, Ownable, AccessContr
   function extendPool(
     uint256 rewardPerSecond,
     uint256 duration
-  ) external onlyRole(MANAGER_ROLE) {
+  ) external onlyRole(DEFAULT_ADMIN_ROLE) {
     _poolData.extendPool(duration);
     _poolData.rewardPerSecond = rewardPerSecond;
+
+    emit ExtendPool(msg.sender, duration, rewardPerSecond);
   }
   
   function closePool() external onlyOwner {
@@ -221,6 +222,7 @@ contract StakingPoolV2 is IStakingPoolV2, StakedElyfiToken, Ownable, AccessContr
     _poolData.endTimestamp = block.timestamp;
     _poolData.isOpened = false;
     _poolData.isFinished = true;
+    emit ClosePool(msg.sender, true);
   }
 
   function retrieveResidue() external onlyOwner {
@@ -233,14 +235,18 @@ contract StakingPoolV2 is IStakingPoolV2, StakedElyfiToken, Ownable, AccessContr
     }
 
     SafeERC20.safeTransfer(rewardAsset, _msgSender(), residueAmount);
+
+    emit RetrieveResidue(msg.sender, residueAmount);
   }
 
   function setManager(address managerAddr) external onlyOwner {
-    _setupRole(MANAGER_ROLE, managerAddr);
+    _setupRole(DEFAULT_ADMIN_ROLE, managerAddr);
+    emit SetManager(msg.sender, managerAddr);
   }
 
   function setEmergency(bool stop) external onlyOwner {
     emergencyStop = stop;
+    emit SetEmergency(msg.sender, stop);
   } 
 
   /***************** Modifier ******************/

--- a/contracts/interface/IStakingPoolV2.sol
+++ b/contracts/interface/IStakingPoolV2.sol
@@ -34,6 +34,20 @@ interface IStakingPoolV2 {
     uint256 endTimestamp
   );
 
+  event ExtendPool(
+    address indexed manager,
+    uint256 duration,
+    uint256 rewardPerSecond
+  );
+
+  event ClosePool(address admin, bool close);
+
+  event RetrieveResidue(address manager, uint256 residueAmount);
+
+  event SetManager(address admin, address manager);
+
+  event SetEmergency(address admin, bool emergency);
+
   function stake(uint256 amount) external;
 
   function claim() external;

--- a/contracts/interface/IStakingPoolV2.sol
+++ b/contracts/interface/IStakingPoolV2.sol
@@ -5,7 +5,7 @@ interface IStakingPoolV2 {
   error StakingNotInitiated();
   error InvalidAmount();
   error ZeroReward();
-  error OnlyAdmin();
+  error OnlyManager();
   error NotEnoughPrincipal(uint256 principal);
   error ZeroPrincipal();
   error Finished();
@@ -45,6 +45,9 @@ interface IStakingPoolV2 {
   event RetrieveResidue(address manager, uint256 residueAmount);
 
   event SetManager(address admin, address manager);
+
+  /// @param requester owner or the manager himself/herself
+  event RevokeManager(address requester, address manager);
 
   event SetEmergency(address admin, bool emergency);
 

--- a/contracts/libraries/StakingPoolLogicV2.sol
+++ b/contracts/libraries/StakingPoolLogicV2.sol
@@ -58,7 +58,7 @@ library StakingPoolLogicV2 {
     emit UpdateStakingPool(msg.sender, poolData.rewardIndex, poolData.totalPrincipal);
   }
 
-  function resetPool(
+  function extendPool(
     StakingPoolV2.PoolData storage poolData,
     uint256 duration
   ) internal {

--- a/test/claim.test.ts
+++ b/test/claim.test.ts
@@ -264,14 +264,14 @@ describe('StakingPool.claim', () => {
       expect(userDataAfterClaim).to.be.equalUserData(expectedUserDataClaim);
     });
 
-    context('amdin set bob as manager', async () => {
+    context('admin set bob as manager', async () => {
       it('bob becomes manager and call extend pool and alice claim', async () => {
         await actions.faucetAndApproveTarget(bob, RAY);
         const poolDataBefore = await getPoolData(testEnv);
         const userDataBefore = await getUserData(testEnv, alice);
         await testEnv.stakingPool.setManager(bob.address);
   
-        advanceTimeTo(secondRoundStartTimestamp)
+        await advanceTimeTo(secondRoundStartTimestamp)
         const tx = await testEnv.stakingPool.connect(bob).extendPool(newRewardPersecond, duration);
         const [expectedPoolData_1, expectedUserData_1] = updatePoolData(
           poolDataBefore,
@@ -300,7 +300,7 @@ describe('StakingPool.claim', () => {
         await actions.faucetAndApproveTarget(bob, RAY);
         await testEnv.stakingPool.setManager(bob.address);
   
-        advanceTimeTo(secondRoundStartTimestamp);
+        await advanceTimeTo(secondRoundStartTimestamp);
         await testEnv.stakingPool.connect(alice).withdraw(amount);
         const poolDataBefore = await getPoolData(testEnv);
         const userDataBefore = await getUserData(testEnv, alice);

--- a/test/claim.test.ts
+++ b/test/claim.test.ts
@@ -263,6 +263,70 @@ describe('StakingPool.claim', () => {
       expect(poolDataAfterClaim).to.be.equalPoolData(expectedPoolDataClaim);
       expect(userDataAfterClaim).to.be.equalUserData(expectedUserDataClaim);
     });
+
+    context('amdin set bob as manager', async () => {
+      it('bob becomes manager and call extend pool and alice claim', async () => {
+        await actions.faucetAndApproveTarget(bob, RAY);
+        const poolDataBefore = await getPoolData(testEnv);
+        const userDataBefore = await getUserData(testEnv, alice);
+        await testEnv.stakingPool.setManager(bob.address);
+  
+        advanceTimeTo(secondRoundStartTimestamp)
+        const tx = await testEnv.stakingPool.connect(bob).extendPool(newRewardPersecond, duration);
+        const [expectedPoolData_1, expectedUserData_1] = updatePoolData(
+          poolDataBefore,
+          userDataBefore,
+          await getTimestamp(tx),
+          duration,
+          newRewardPersecond
+        );
+        
+        const claimTx = await testEnv.stakingPool.connect(alice).claim();
+        const [expectedPoolData_2, expectedUserData_2] = expectDataAfterClaim(
+          expectedPoolData_1,
+          expectedUserData_1,
+          await getTimestamp(claimTx)
+        );
+   
+        const poolDataAfter = await getPoolData(testEnv);
+        const userDataAfter = await getUserData(testEnv, alice);
+  
+        expect(poolDataAfter).eql(expectedPoolData_2);
+        expect(userDataAfter).eql(expectedUserData_2);
+      });
+
+      it('alice action and bob becomes manager and call extend pool ', async () => {
+        await testEnv.stakingPool.connect(alice).stake(amount);
+        await actions.faucetAndApproveTarget(bob, RAY);
+        await testEnv.stakingPool.setManager(bob.address);
+  
+        advanceTimeTo(secondRoundStartTimestamp);
+        await testEnv.stakingPool.connect(alice).withdraw(amount);
+        const poolDataBefore = await getPoolData(testEnv);
+        const userDataBefore = await getUserData(testEnv, alice);
+        const tx = await testEnv.stakingPool.connect(bob).extendPool(newRewardPersecond, duration);
+        const [expectedPoolData_1, expectedUserData_1] = updatePoolData(
+          poolDataBefore,
+          userDataBefore,
+          await getTimestamp(tx),
+          duration,
+          newRewardPersecond
+        );
+        
+        const stakeTx = await testEnv.stakingPool.connect(alice).claim();
+        const [expectedPoolData_2, expectedUserData_2] = expectDataAfterClaim(
+          expectedPoolData_1,
+          expectedUserData_1,
+          await getTimestamp(stakeTx)
+        );
+   
+        const poolDataAfter = await getPoolData(testEnv);
+        const userDataAfter = await getUserData(testEnv, alice);
+  
+        expect(poolDataAfter).eql(expectedPoolData_2);
+        expect(userDataAfter).eql(expectedUserData_2);
+      });
+    });
   });
 
   context('in case of emergency', async () => {

--- a/test/claim.test.ts
+++ b/test/claim.test.ts
@@ -49,8 +49,8 @@ describe('StakingPool.claim', () => {
   beforeEach('deploy staking pool', async () => {
     testEnv = await loadFixture(fixture);
     actions = createTestActions(testEnv);
-    await actions.faucetAndApproveReward(deployer, RAY);
-    await actions.faucetAndApproveTarget(alice, RAY);
+    await actions.faucetAndApproveReward(deployer);
+    await actions.faucetAndApproveTarget(alice);
   });
 
   it('reverts if the pool has not initiated', async () => {

--- a/test/settings.test.ts
+++ b/test/settings.test.ts
@@ -5,7 +5,7 @@ import { expect } from 'chai';
 import TestEnv from './types/TestEnv';
 import { RAY, SECONDSPERDAY, WAD } from './utils/constants';
 import { setTestEnv } from './utils/testEnv';
-import { toTimestamp } from './utils/time';
+import { advanceTimeTo, toTimestamp } from './utils/time';
 
 const { loadFixture } = waffle;
 
@@ -93,18 +93,33 @@ describe('StakingPool.settings', () => {
     });
   });
 
-  context('reset the pool', async () => {
-    it('revert if a person not admin try reset the pool', async () => {
+  context('authority to call extend pool function', async () => {
+    beforeEach('init pool', async () => {
       await testEnv.rewardAsset.connect(deployer).faucet();
       await testEnv.rewardAsset.connect(deployer).approve(testEnv.stakingPool.address, RAY);
-      await testEnv.stakingPool
+      const tx = await testEnv.stakingPool
         .connect(deployer)
         .initNewPool(rewardPerSecond, startTimestamp, duration);
+      advanceTimeTo(startTimestamp);
+    });
 
+    it('revert if a person not admin try extend the pool', async () => {
+      // TODO 
+      /*
       await expect(
-        testEnv.stakingPool.connect(depositor).extendPool(BigNumber.from(utils.parseEther('1')), BigNumber.from(30).mul(SECONDSPERDAY))
-      ).to.be.revertedWith('Ownable: caller is not the owner');
-    })
-  })
+        testEnv.stakingPool.connect(depositor).extendPool(BigNumber.from(utils.parseEther('2')), BigNumber.from(30).mul(SECONDSPERDAY))
+      ).to.be.revertedWith('OnlyAdmin');
+      */
+    });
+
+    it('success when alice is set up as a manger by amdin and', async () => {
+      await expect(testEnv.stakingPool.connect(depositor).setManager(depositor.address))
+      .to.be.revertedWith(
+        'OnlyAdmin'
+      );
+      await testEnv.stakingPool.connect(deployer).setManager(depositor.address);
+      await testEnv.stakingPool.connect(depositor).extendPool(rewardPerSecond,duration);
+    });
+  });
 });
 

--- a/test/settings.test.ts
+++ b/test/settings.test.ts
@@ -112,13 +112,15 @@ describe('StakingPool.settings', () => {
       */
     });
 
-    it('success when alice is set up as a manger by amdin and', async () => {
+    it('success when alice is set up as a manger by amdin', async () => {
       await expect(testEnv.stakingPool.connect(depositor).setManager(depositor.address))
       .to.be.revertedWith(
-        'OnlyAdmin'
+        'Ownable: caller is not the owner'
       );
-      await testEnv.stakingPool.connect(deployer).setManager(depositor.address);
-      await testEnv.stakingPool.connect(depositor).extendPool(rewardPerSecond,duration);
+      await expect(testEnv.stakingPool.connect(deployer).setManager(depositor.address))
+      .to.emit(testEnv.stakingPool, 'SetManager');
+      await expect(testEnv.stakingPool.connect(depositor).extendPool(rewardPerSecond,duration))
+      .to.emit(testEnv.stakingPool, 'ExtendPool');
     });
   });
 });

--- a/test/settings.test.ts
+++ b/test/settings.test.ts
@@ -97,7 +97,7 @@ describe('StakingPool.settings', () => {
     beforeEach('init pool', async () => {
       await testEnv.rewardAsset.connect(deployer).faucet();
       await testEnv.rewardAsset.connect(deployer).approve(testEnv.stakingPool.address, RAY);
-      const tx = await testEnv.stakingPool
+      await testEnv.stakingPool
         .connect(deployer)
         .initNewPool(rewardPerSecond, startTimestamp, duration);
       advanceTimeTo(startTimestamp);

--- a/test/settings.test.ts
+++ b/test/settings.test.ts
@@ -100,7 +100,7 @@ describe('StakingPool.settings', () => {
       await testEnv.stakingPool
         .connect(deployer)
         .initNewPool(rewardPerSecond, startTimestamp, duration);
-      advanceTimeTo(startTimestamp);
+      await advanceTimeTo(startTimestamp);
     });
 
     it('revert if a person not admin try extend the pool', async () => {

--- a/test/stake.test.ts
+++ b/test/stake.test.ts
@@ -21,14 +21,18 @@ describe('StakingPool.stake', () => {
 
   const rewardPersecond = BigNumber.from(utils.parseEther('1'));
   const year = BigNumber.from(2022);
-  const month = BigNumber.from(7);
-  const day = BigNumber.from(7);
+  const month_1 = BigNumber.from(7);
+  const day_1 = BigNumber.from(7);
   const duration = BigNumber.from(30).mul(SECONDSPERDAY);
 
   const month_end = BigNumber.from(8);
   const day_end = BigNumber.from(20);
 
-  const startTimestamp = toTimestamp(year, month, day, BigNumber.from(10));
+  const month_2 = BigNumber.from(8);
+  const day_2 = BigNumber.from(6);
+
+  const firstTimestamp = toTimestamp(year, month_1, day_1, BigNumber.from(10));
+  const secondTimestamp = toTimestamp(year, month_2, day_2, BigNumber.from(10));
   const endTimestamp = toTimestamp(year, month_end, day_end, BigNumber.from(10));
 
   const stakeAmount = utils.parseEther('10');
@@ -55,8 +59,8 @@ describe('StakingPool.stake', () => {
       beforeEach(async () => {
         await testEnv.stakingPool
           .connect(deployer)
-          .initNewPool(rewardPersecond, startTimestamp, duration);
-        await advanceTimeTo(startTimestamp);
+          .initNewPool(rewardPersecond, firstTimestamp, duration);
+        await advanceTimeTo(firstTimestamp);
       });
 
       it('reverts if user staking amount is 0', async () => {
@@ -98,7 +102,7 @@ describe('StakingPool.stake', () => {
         it('revert if open the pool already finished', async () => {
           await actions.closePool(deployer);
           await expect(
-            actions.initNewPool(deployer, rewardPersecond, startTimestamp, duration)
+            actions.initNewPool(deployer, rewardPersecond, firstTimestamp, duration)
           ).to.be.revertedWith('Finished');
         });
 
@@ -112,9 +116,9 @@ describe('StakingPool.stake', () => {
 
   context('staking scenario', async () => {
     beforeEach('init the pool and time passes', async () => {
-      await actions.initNewPool(deployer, rewardPersecond, startTimestamp, duration);
-      actions.faucetAndApproveTarget(bob, RAY);
-      await advanceTimeTo(startTimestamp);
+      await actions.initNewPool(deployer, rewardPersecond, firstTimestamp, duration);
+      const tx = actions.faucetAndApproveTarget(bob, RAY);
+      await advanceTimeTo(firstTimestamp);
     });
 
     it('first stake and second stake from alice', async () => {
@@ -210,9 +214,9 @@ describe('StakingPool.stake', () => {
     beforeEach('init the pool and stake in pool', async () => {
       await testEnv.stakingPool
         .connect(deployer)
-        .initNewPool(rewardPersecond, startTimestamp, duration);
+        .initNewPool(rewardPersecond, firstTimestamp, duration);
       const tx = await testEnv.stakingAsset.connect(alice).approve(testEnv.stakingPool.address, RAY);
-      await advanceTimeTo(startTimestamp);
+      await advanceTimeTo(firstTimestamp);
       await testEnv.stakingPool.connect(alice).stake(stakeAmount);
       await testEnv.rewardAsset.connect(deployer).transfer(testEnv.stakingPool.address, ethers.utils.parseEther('100'));
     });
@@ -290,6 +294,39 @@ describe('StakingPool.stake', () => {
       expect(poolDataAfter_2).to.be.equalPoolData(expectedPoolData_3);
       expect(userDataAfter_2).to.be.equalUserData(expectedUserData_3);
     });
+
+    // FIXME!!
+    it('bob becomes manager and call extend pool and alice stakes', async () => {
+      await actions.faucetAndApproveTarget(bob, RAY);
+      const poolDataBefore = await getPoolData(testEnv);
+      const userDataBefore = await getUserData(testEnv, alice);
+      
+      const setManagertx = await testEnv.stakingPool.setManager(bob.address);
+      advanceTimeTo(secondTimestamp)
+      const tx = await testEnv.stakingPool.connect(bob).extendPool(newRewardPersecond, duration);
+  
+      const [expectedPoolData_1, expectedUserData_1] = updatePoolData(
+        poolDataBefore,
+        userDataBefore,
+        await getTimestamp(tx),
+        duration,
+        newRewardPersecond
+      );
+  
+      const stakeTx = await testEnv.stakingPool.connect(alice).stake(stakeAmount);
+      const [expectedPoolData_2, expectedUserData_2] = expectDataAfterStake(
+        expectedPoolData_1,
+        expectedUserData_1,
+        await getTimestamp(stakeTx),
+        stakeAmount
+      );
+  
+      const poolDataAfter = await getPoolData(testEnv);
+      const userDataAfter = await getUserData(testEnv, alice);
+  
+      expect(poolDataAfter).eql(expectedPoolData_2);
+      expect(userDataAfter).eql(expectedUserData_2);
+    });
   });
 
   context('in case of emergency', async () => {
@@ -300,12 +337,12 @@ describe('StakingPool.stake', () => {
         .connect(deployer)
         .initNewPool(
           rewardPersecond,
-          startTimestamp,
+          firstTimestamp,
           duration
         );
       await testEnv.stakingAsset.connect(alice).faucet();
       const tx = await testEnv.stakingAsset.connect(alice).approve(testEnv.stakingPool.address, RAY);
-      await advanceTimeTo(startTimestamp);
+      await advanceTimeTo(firstTimestamp);
       await testEnv.stakingPool.connect(alice).stake(stakeAmount);
     });
 

--- a/test/stake.test.ts
+++ b/test/stake.test.ts
@@ -117,7 +117,7 @@ describe('StakingPool.stake', () => {
   context('staking scenario', async () => {
     beforeEach('init the pool and time passes', async () => {
       await actions.initNewPool(deployer, rewardPersecond, firstTimestamp, duration);
-      const tx = actions.faucetAndApproveTarget(bob, RAY);
+      actions.faucetAndApproveTarget(bob, RAY);
       await advanceTimeTo(firstTimestamp);
     });
 
@@ -302,7 +302,7 @@ describe('StakingPool.stake', () => {
         const userDataBefore = await getUserData(testEnv, alice);
         await testEnv.stakingPool.setManager(bob.address);
   
-        advanceTimeTo(secondTimestamp)
+        await advanceTimeTo(secondTimestamp)
         const tx = await testEnv.stakingPool.connect(bob).extendPool(newRewardPersecond, duration);
         const [expectedPoolData_1, expectedUserData_1] = updatePoolData(
           poolDataBefore,
@@ -332,7 +332,7 @@ describe('StakingPool.stake', () => {
         await actions.faucetAndApproveTarget(bob, RAY);
         await testEnv.stakingPool.setManager(bob.address);
   
-        advanceTimeTo(secondTimestamp);
+        await advanceTimeTo(secondTimestamp);
         await testEnv.stakingPool.connect(alice).withdraw(stakeAmount);
         const poolDataBefore = await getPoolData(testEnv);
         const userDataBefore = await getUserData(testEnv, alice);
@@ -374,7 +374,7 @@ describe('StakingPool.stake', () => {
           duration
         );
       await testEnv.stakingAsset.connect(alice).faucet();
-      const tx = await testEnv.stakingAsset.connect(alice).approve(testEnv.stakingPool.address, RAY);
+      await testEnv.stakingAsset.connect(alice).approve(testEnv.stakingPool.address, RAY);
       await advanceTimeTo(firstTimestamp);
       await testEnv.stakingPool.connect(alice).stake(stakeAmount);
     });

--- a/test/utils/expect.ts
+++ b/test/utils/expect.ts
@@ -171,7 +171,8 @@ export function updatePoolData(
     userData,
     txTimeStamp
   );
-  newPoolData.startTimestamp = poolData.lastUpdateTimestamp = txTimeStamp;
+
+  newPoolData.startTimestamp = newPoolData.lastUpdateTimestamp = txTimeStamp;
   newPoolData.endTimestamp = txTimeStamp.add(duration);
   newPoolData.rewardPerSecond = rewardPerSecond;
 

--- a/test/utils/helpers.ts
+++ b/test/utils/helpers.ts
@@ -1,11 +1,12 @@
+import { MAX_UINT_AMOUNT } from './constants';
 import { BigNumber, Wallet, ethers } from 'ethers';
 import PoolData from '../types/PoolData';
 import TestEnv from '../types/TestEnv';
 import UserData from '../types/UserData';
 
 export type TestHelperActions = {
-  faucetAndApproveTarget: (wallet: Wallet, amount: string) => Promise<void>
-  faucetAndApproveReward: (wallet: Wallet, amount: string) => Promise<void>
+  faucetAndApproveTarget: (wallet: Wallet, amount?: string) => Promise<void>
+  faucetAndApproveReward: (wallet: Wallet, amount?: string) => Promise<void>
   stake: (wallet: Wallet, amount: BigNumber) => Promise<ethers.ContractTransaction>
   withdraw: (wallet: Wallet, amount: BigNumber) => Promise<ethers.ContractTransaction>
   claim: (wallet: Wallet) => Promise<ethers.ContractTransaction>
@@ -26,16 +27,22 @@ export const createTestActions = (testEnv: TestEnv): TestHelperActions => {
   // A target is the token staked.
   const faucetAndApproveTarget = async (
     wallet: Wallet,
-    amount: string,
+    amount?: string,
   ) => {
+    if (amount === undefined) {
+      amount = MAX_UINT_AMOUNT;
+    }
     await testEnv.stakingAsset.connect(wallet).faucet();
     await testEnv.stakingAsset.connect(wallet).approve(testEnv.stakingPool.address, amount);
   }
 
   const faucetAndApproveReward = async (
     wallet: Wallet,
-    amount: string,
+    amount?: string,
   ) => {
+    if (amount === undefined) {
+      amount = MAX_UINT_AMOUNT;
+    }
     await testEnv.rewardAsset.connect(wallet).faucet();
     await testEnv.rewardAsset.connect(wallet).approve(testEnv.stakingPool.address, amount);
   }

--- a/test/withdraw.test.ts
+++ b/test/withdraw.test.ts
@@ -26,7 +26,7 @@ describe('StakingPool.withdraw', () => {
   const duration = BigNumber.from(30).mul(SECONDSPERDAY);
 
   const month_2 = BigNumber.from(7);
-  const day_2 = BigNumber.from(9);
+  const day_2 = BigNumber.from(20);
 
   const firstTimestamp = toTimestamp(year, month_1, day_1, BigNumber.from(10));
   const secondTimestamp = toTimestamp(year, month_2, day_2, BigNumber.from(10));
@@ -361,6 +361,74 @@ describe('StakingPool.withdraw', () => {
 
         expect(poolDataAfterWithdraw).eql(expectedPoolDataWithdraw);
         expect(userDataAfterWithdraw).eql(expectedUserDataWithdraw);
+      });
+
+
+      context('amdin set bob as manager', async () => {
+        it('bob becomes manager and call extend pool and alice withdraw', async () => {
+          await actions.faucetAndApproveTarget(bob, RAY);
+          const poolDataBefore = await getPoolData(testEnv);
+          const userDataBefore = await getUserData(testEnv, alice);
+          await testEnv.stakingPool.setManager(bob.address);
+    
+          advanceTimeTo(secondTimestamp)
+          const tx = await testEnv.stakingPool.connect(bob).extendPool(newRewardPersecond, duration);
+          const [expectedPoolData_1, expectedUserData_1] = updatePoolData(
+            poolDataBefore,
+            userDataBefore,
+            await getTimestamp(tx),
+            duration,
+            newRewardPersecond
+          );
+          
+          const withdrawTx = await testEnv.stakingPool.connect(alice).withdraw(amount);
+          const [expectedPoolData_2, expectedUserData_2] = expectDataAfterWithdraw(
+            expectedPoolData_1,
+            expectedUserData_1,
+            await getTimestamp(withdrawTx),
+            amount
+          );
+     
+          const poolDataAfter = await getPoolData(testEnv);
+          const userDataAfter = await getUserData(testEnv, alice);
+    
+          expect(poolDataAfter).eql(expectedPoolData_2);
+          expect(userDataAfter).eql(expectedUserData_2);
+        });
+  
+        it('alice action and bob becomes manager and call extend pool ', async () => {
+          await testEnv.stakingPool.connect(alice).stake(amount);
+          await actions.faucetAndApproveTarget(bob, RAY);
+          await testEnv.stakingPool.setManager(bob.address);
+    
+          advanceTimeTo(secondTimestamp);
+          await testEnv.stakingPool.connect(alice).claim();
+          const poolDataBefore = await getPoolData(testEnv);
+          const userDataBefore = await getUserData(testEnv, alice);
+
+          const tx = await testEnv.stakingPool.connect(bob).extendPool(newRewardPersecond, duration);
+          const [expectedPoolData_1, expectedUserData_1] = updatePoolData(
+            poolDataBefore,
+            userDataBefore,
+            await getTimestamp(tx),
+            duration,
+            newRewardPersecond
+          );
+          
+          const stakeTx = await testEnv.stakingPool.connect(alice).withdraw(amount);
+          const [expectedPoolData_2, expectedUserData_2] = expectDataAfterWithdraw(
+            expectedPoolData_1,
+            expectedUserData_1,
+            await getTimestamp(stakeTx),
+            amount
+          );
+     
+          const poolDataAfter = await getPoolData(testEnv);
+          const userDataAfter = await getUserData(testEnv, alice);
+    
+          expect(poolDataAfter).eql(expectedPoolData_2);
+          expect(userDataAfter).eql(expectedUserData_2);
+        });
       });
     });
 

--- a/test/withdraw.test.ts
+++ b/test/withdraw.test.ts
@@ -251,7 +251,7 @@ describe('StakingPool.withdraw', () => {
         await testEnv.stakingPool
           .connect(deployer)
           .initNewPool(rewardPersecond, firstTimestamp, duration);
-        const tx = await testEnv.stakingAsset.connect(alice).approve(testEnv.stakingPool.address, RAY);
+        await testEnv.stakingAsset.connect(alice).approve(testEnv.stakingPool.address, RAY);
         await advanceTimeTo(firstTimestamp);
         await testEnv.stakingPool.connect(alice).stake(amount.mul(3));
         await testEnv.rewardAsset.connect(deployer).transfer(testEnv.stakingPool.address, ethers.utils.parseEther('100'));
@@ -371,7 +371,7 @@ describe('StakingPool.withdraw', () => {
           const userDataBefore = await getUserData(testEnv, alice);
           await testEnv.stakingPool.setManager(bob.address);
     
-          advanceTimeTo(secondTimestamp)
+          await advanceTimeTo(secondTimestamp)
           const tx = await testEnv.stakingPool.connect(bob).extendPool(newRewardPersecond, duration);
           const [expectedPoolData_1, expectedUserData_1] = updatePoolData(
             poolDataBefore,
@@ -401,7 +401,7 @@ describe('StakingPool.withdraw', () => {
           await actions.faucetAndApproveTarget(bob, RAY);
           await testEnv.stakingPool.setManager(bob.address);
     
-          advanceTimeTo(secondTimestamp);
+          await advanceTimeTo(secondTimestamp);
           await testEnv.stakingPool.connect(alice).claim();
           const poolDataBefore = await getPoolData(testEnv);
           const userDataBefore = await getUserData(testEnv, alice);

--- a/test/withdraw.test.ts
+++ b/test/withdraw.test.ts
@@ -364,7 +364,7 @@ describe('StakingPool.withdraw', () => {
       });
 
 
-      context('amdin set bob as manager', async () => {
+      context('amdin sets bob as manager', async () => {
         it('bob becomes manager and call extend pool and alice withdraw', async () => {
           await actions.faucetAndApproveTarget(bob, RAY);
           const poolDataBefore = await getPoolData(testEnv);


### PR DESCRIPTION
The admin registers a different address as a manager, and the admin can set the duration and rewardPerSecond of the next staking pool.