### PR TITLE
Add a helper: resetTimestampTo

### DIFF
--- a/test/retrieveResidue.test.ts
+++ b/test/retrieveResidue.test.ts
@@ -64,7 +64,7 @@ describe('StakingPool.retrieveResidue', () => {
         await asset.connect(deployer).faucet();
 
         // This also sends the reward asset which amounts to rewardPerSecond * duration 
-        const initNewPoolTx = await stakingPool
+        await stakingPool
           .connect(deployer)
           .initNewPool(rewardPerSecond, startTimestamp, duration);
 

--- a/test/settings.test.ts
+++ b/test/settings.test.ts
@@ -73,26 +73,6 @@ describe('StakingPool.settings', () => {
 
   });
 
-  context('retrieveResidue', async () => {
-    beforeEach('set', async () => {
-      await testEnv.rewardAsset.connect(deployer).faucet();
-      await testEnv.rewardAsset.connect(deployer).approve(testEnv.stakingPool.address, RAY);
-    });
-
-    it('reverts if general account call', async () => {
-      await expect(testEnv.stakingPool.connect(depositor).retrieveResidue()).to.be.revertedWith(
-        'Ownable: caller is not the owner'
-      );
-    });
-
-    it('success', async () => {
-      const tx = await testEnv.stakingPool.connect(deployer).retrieveResidue();
-      await expect(tx)
-        .to.emit(testEnv.rewardAsset, 'Transfer')
-        .withArgs(testEnv.stakingPool.address, deployer.address, RAY);
-    });
-  });
-
   context('reset the pool', async () => {
     it('revert if a person not admin try reset the pool', async () => {
       await testEnv.rewardAsset.connect(deployer).faucet();

--- a/test/stake.test.ts
+++ b/test/stake.test.ts
@@ -4,7 +4,7 @@ import { expect } from 'chai';
 import TestEnv from './types/TestEnv';
 import { RAY, SECONDSPERDAY } from './utils/constants';
 import { setTestEnv } from './utils/testEnv';
-import { advanceTimeTo, getTimestamp, toTimestamp } from './utils/time';
+import { advanceTimeTo, resetTimestampTo, getTimestamp, toTimestamp } from './utils/time';
 import { expectDataAfterStake, updatePoolData } from './utils/expect';
 import { createTestActions, getPoolData, getUserData, TestHelperActions } from './utils/helpers';
 
@@ -56,7 +56,7 @@ describe('StakingPool.stake', () => {
         await testEnv.stakingPool
           .connect(deployer)
           .initNewPool(rewardPersecond, startTimestamp, duration);
-        await advanceTimeTo(startTimestamp);
+        await resetTimestampTo(startTimestamp);
       });
 
       it('reverts if user staking amount is 0', async () => {
@@ -114,7 +114,7 @@ describe('StakingPool.stake', () => {
     beforeEach('init the pool and time passes', async () => {
       await actions.initNewPool(deployer, rewardPersecond, startTimestamp, duration);
       actions.faucetAndApproveTarget(bob, RAY);
-      await advanceTimeTo(startTimestamp);
+      await resetTimestampTo(startTimestamp);
     });
 
     it('first stake and second stake from alice', async () => {
@@ -211,8 +211,8 @@ describe('StakingPool.stake', () => {
       await testEnv.stakingPool
         .connect(deployer)
         .initNewPool(rewardPersecond, startTimestamp, duration);
-      const tx = await testEnv.stakingAsset.connect(alice).approve(testEnv.stakingPool.address, RAY);
-      await advanceTimeTo(startTimestamp);
+      await testEnv.stakingAsset.connect(alice).approve(testEnv.stakingPool.address, RAY);
+      await resetTimestampTo(startTimestamp);
       await testEnv.stakingPool.connect(alice).stake(stakeAmount);
       await testEnv.rewardAsset.connect(deployer).transfer(testEnv.stakingPool.address, ethers.utils.parseEther('100'));
     });
@@ -304,8 +304,8 @@ describe('StakingPool.stake', () => {
           duration
         );
       await testEnv.stakingAsset.connect(alice).faucet();
-      const tx = await testEnv.stakingAsset.connect(alice).approve(testEnv.stakingPool.address, RAY);
-      await advanceTimeTo(startTimestamp);
+      await testEnv.stakingAsset.connect(alice).approve(testEnv.stakingPool.address, RAY);
+      await resetTimestampTo(startTimestamp);
       await testEnv.stakingPool.connect(alice).stake(stakeAmount);
     });
 

--- a/test/utils/time.ts
+++ b/test/utils/time.ts
@@ -54,8 +54,7 @@ export async function resetTimestampTo(targetInput: BigNumber | number) {
 
 export async function advanceTimeTo(targetInput: BigNumber | number) {
   const target = (targetInput instanceof BigNumber) ? targetInput.toNumber() : targetInput;
-  await waffle.provider.send("evm_setNextBlockTimestamp", [target])
-  return await waffle.provider.send('evm_mine', []);
+  return await waffle.provider.send('evm_mine', [target]);
 }
 
 export async function advanceBlockTo(to: number) {

--- a/test/utils/time.ts
+++ b/test/utils/time.ts
@@ -45,9 +45,17 @@ export async function advanceTime(secondsToIncrease: number) {
   return await waffle.provider.send('evm_mine', []);
 }
 
+export async function resetTimestampTo(targetInput: BigNumber | number) {
+  const target = (targetInput instanceof BigNumber) ? targetInput.toNumber() : targetInput;
+  const now = (await waffle.provider.getBlock('latest')).timestamp;
+  await waffle.provider.send("evm_increaseTime", [target - now])
+  return await waffle.provider.send('evm_mine', []);
+}
+
 export async function advanceTimeTo(targetInput: BigNumber | number) {
   const target = (targetInput instanceof BigNumber) ? targetInput.toNumber() : targetInput;
-  return await waffle.provider.send('evm_mine', [target]);
+  await waffle.provider.send("evm_setNextBlockTimestamp", [target])
+  return await waffle.provider.send('evm_mine', []);
 }
 
 export async function advanceBlockTo(to: number) {


### PR DESCRIPTION
## Problem
In the hardhat network, `evm_mine` does not allow the timestamp of the
block to be lower than the previous block.
This causes errors in some tests because we want to go back to when the
pool starts.

## Solution
Add a test helper `resetTimestampTo`. I divide `advanceTimeTo` and
`resetTimestampTo` because it is helpful to know when the time may go back.

## Test
All passes.