### PR TITLE
Keep a manager role w/o openzeppelin AccessControl

### DIFF
--- a/contracts/StakingPoolV2.sol
+++ b/contracts/StakingPoolV2.sol
@@ -19,7 +19,6 @@ contract StakingPoolV2 is IStakingPoolV2, StakedElyfiToken, Ownable {
   constructor(IERC20 stakingAsset_, IERC20 rewardAsset_) StakedElyfiToken(stakingAsset_) {
     stakingAsset = stakingAsset_;
     rewardAsset = rewardAsset_;
-    _setManager(msg.sender);
   }
 
   struct PoolData {
@@ -255,7 +254,7 @@ contract StakingPoolV2 is IStakingPoolV2, StakedElyfiToken, Ownable {
   } 
 
   function isManager(address addr) public view returns (bool) {
-    return managers[addr];
+    return managers[addr] || addr == owner();
   }
 
   /***************** private ******************/

--- a/contracts/StakingPoolV2.sol
+++ b/contracts/StakingPoolV2.sol
@@ -208,7 +208,7 @@ contract StakingPoolV2 is IStakingPoolV2, StakedElyfiToken, Ownable {
   function extendPool(
     uint256 rewardPerSecond,
     uint256 duration
-  ) external onlyManager(msg.sender) {
+  ) external onlyManager {
     _poolData.extendPool(duration);
     _poolData.rewardPerSecond = rewardPerSecond;
 
@@ -274,8 +274,8 @@ contract StakingPoolV2 is IStakingPoolV2, StakedElyfiToken, Ownable {
   }
 
   /***************** Modifier ******************/
-  modifier onlyManager(address addr) {
-    if (!isManager(addr)) revert OnlyManager();
+  modifier onlyManager() {
+    if (!isManager(msg.sender)) revert OnlyManager();
     _;
   }
 

--- a/contracts/StakingPoolV2.sol
+++ b/contracts/StakingPoolV2.sol
@@ -262,12 +262,14 @@ contract StakingPoolV2 is IStakingPoolV2, StakedElyfiToken, Ownable {
   function _setManager(address addr) private {
     if (!isManager(addr)) {
       managers[addr] = true;
+      emit SetManager(msg.sender, addr);
     }
   }
 
   function _revokeManager(address addr) private {
     if (isManager(addr)) {
       managers[addr] = false;
+      emit RevokeManager(msg.sender, addr);
     }
   }
 

--- a/contracts/StakingPoolV2.sol
+++ b/contracts/StakingPoolV2.sol
@@ -20,7 +20,6 @@ contract StakingPoolV2 is IStakingPoolV2, StakedElyfiToken, Ownable, AccessContr
   constructor(IERC20 stakingAsset_, IERC20 rewardAsset_) StakedElyfiToken(stakingAsset_) {
     stakingAsset = stakingAsset_;
     rewardAsset = rewardAsset_;
-    _admin = msg.sender;
     _setupRole(MANAGER_ROLE, msg.sender);
   }
 
@@ -41,7 +40,6 @@ contract StakingPoolV2 is IStakingPoolV2, StakedElyfiToken, Ownable, AccessContr
 
   bool internal emergencyStop = false;
   bytes32 public constant MANAGER_ROLE = keccak256("MANAGER_ROLE");
-  address internal _admin;
   IERC20 public stakingAsset;
   IERC20 public rewardAsset;
   PoolData internal _poolData;

--- a/contracts/StakingPoolV2.sol
+++ b/contracts/StakingPoolV2.sol
@@ -229,7 +229,7 @@ contract StakingPoolV2 is IStakingPoolV2, StakedElyfiToken, Ownable {
       residueAmount = rewardAsset.balanceOf(address(this));
     }
 
-    SafeERC20.safeTransfer(rewardAsset, _msgSender(), residueAmount);
+    SafeERC20.safeTransfer(rewardAsset, msg.sender, residueAmount);
   }
 
   function setManager(address addr) external onlyOwner {
@@ -241,7 +241,7 @@ contract StakingPoolV2 is IStakingPoolV2, StakedElyfiToken, Ownable {
   }
 
   function renounceManager(address addr) external {
-    require(addr == _msgSender(), "Can only renounce manager for self");
+    require(addr == msg.sender, "Can only renounce manager for self");
     _revokeManager(addr);
   }
 

--- a/contracts/interface/IStakingPoolV2.sol
+++ b/contracts/interface/IStakingPoolV2.sol
@@ -46,6 +46,9 @@ interface IStakingPoolV2 {
 
   event SetManager(address admin, address manager);
 
+  /// @param requester owner or the manager himself/herself
+  event RevokeManager(address requester, address manager);
+
   event SetEmergency(address admin, bool emergency);
 
   function stake(uint256 amount) external;

--- a/contracts/interface/IStakingPoolV2.sol
+++ b/contracts/interface/IStakingPoolV2.sol
@@ -5,7 +5,7 @@ interface IStakingPoolV2 {
   error StakingNotInitiated();
   error InvalidAmount();
   error ZeroReward();
-  error OnlyAdmin();
+  error OnlyManager();
   error NotEnoughPrincipal(uint256 principal);
   error ZeroPrincipal();
   error Finished();

--- a/test/claim.test.ts
+++ b/test/claim.test.ts
@@ -49,8 +49,8 @@ describe('StakingPool.claim', () => {
   beforeEach('deploy staking pool', async () => {
     testEnv = await loadFixture(fixture);
     actions = createTestActions(testEnv);
-    await actions.faucetAndApproveReward(deployer, RAY);
-    await actions.faucetAndApproveTarget(alice, RAY);
+    await actions.faucetAndApproveReward(deployer);
+    await actions.faucetAndApproveTarget(alice);
   });
 
   it('reverts if the pool has not initiated', async () => {

--- a/test/settings.test.ts
+++ b/test/settings.test.ts
@@ -77,6 +77,12 @@ describe('StakingPool.settings', () => {
     });
   });
 
+  describe('isManager', async () => {
+    it('always returns true for the owner', async () => {
+      expect(await testEnv.stakingPool.isManager(deployer.address)).to.equal(true);
+    })
+  });
+
   describe('.revokeManager', async () => {
     it('is onlyOwner', async () => {
       await expect(testEnv.stakingPool.connect(depositor).revokeManager(depositor.address))

--- a/test/settings.test.ts
+++ b/test/settings.test.ts
@@ -6,6 +6,7 @@ import TestEnv from './types/TestEnv';
 import { RAY, SECONDSPERDAY, WAD } from './utils/constants';
 import { setTestEnv } from './utils/testEnv';
 import { resetTimestampTo, toTimestamp } from './utils/time';
+import { createTestActions, getPoolData, getUserData, TestHelperActions } from './utils/helpers';
 
 const { loadFixture } = waffle;
 
@@ -13,6 +14,7 @@ require('./utils/matchers.ts');
 
 describe('StakingPool.settings', () => {
   let testEnv: TestEnv;
+  let actions: TestHelperActions;
 
   const provider = waffle.provider;
   const [deployer, depositor] = provider.getWallets();
@@ -36,7 +38,8 @@ describe('StakingPool.settings', () => {
 
   beforeEach(async () => {
     testEnv = await loadFixture(fixture);
-    await testEnv.stakingAsset.connect(depositor).faucet();
+    actions = createTestActions(testEnv);
+    await actions.faucetAndApproveTarget(depositor);
   });
 
   it('staking pool deployed', async () => {
@@ -44,59 +47,68 @@ describe('StakingPool.settings', () => {
     expect(await testEnv.stakingPool.rewardAsset()).to.be.equal(testEnv.rewardAsset.address);
   });
 
-  context('when the staking pool deployed', async () => {
-    it('reverts if general account initiate the pool', async () => {
-      await testEnv.rewardAsset.connect(depositor).faucet();
-      await testEnv.rewardAsset.connect(depositor).approve(testEnv.stakingPool.address, RAY);
-      await expect(
-        testEnv.stakingPool
-          .connect(depositor)
-          .initNewPool(rewardPerSecond, startTimestamp, duration)
-      ).to.be.revertedWith('Ownable: caller is not the owner');
+  describe('.initNewPool', () => {
+    context('when the staking pool is deployed', async () => {
+      it('reverts if general account initiates the pool', async () => {
+        await testEnv.rewardAsset.connect(depositor).faucet();
+        await testEnv.rewardAsset.connect(depositor).approve(testEnv.stakingPool.address, RAY);
+        await expect(
+          testEnv.stakingPool
+            .connect(depositor)
+            .initNewPool(rewardPerSecond, startTimestamp, duration)
+        ).to.be.revertedWith('Ownable: caller is not the owner');
+      });
+
+      it('succeeds if an owner initates the pool', async () => {
+        await testEnv.rewardAsset.connect(deployer).faucet();
+        await testEnv.rewardAsset.connect(deployer).approve(testEnv.stakingPool.address, RAY);
+        await testEnv.stakingPool
+          .connect(deployer)
+          .initNewPool(rewardPerSecond, startTimestamp, duration);
+
+        const poolData = await testEnv.stakingPool.getPoolData();
+
+        expect(poolData.rewardPerSecond).to.be.equal(rewardPerSecond);
+        expect(poolData.rewardIndex).to.be.equal(WAD);
+        expect(poolData.startTimestamp).to.be.equal(startTimestamp);
+        expect(poolData.endTimestamp).to.be.equal(endTimestamp);
+        expect(poolData.totalPrincipal).to.be.equal(0);
+      });
     });
-
-    it('success', async () => {
-      await testEnv.rewardAsset.connect(deployer).faucet();
-      await testEnv.rewardAsset.connect(deployer).approve(testEnv.stakingPool.address, RAY);
-      await testEnv.stakingPool
-        .connect(deployer)
-        .initNewPool(rewardPerSecond, startTimestamp, duration);
-
-      const poolData = await testEnv.stakingPool.getPoolData();
-
-      expect(poolData.rewardPerSecond).to.be.equal(rewardPerSecond);
-      expect(poolData.rewardIndex).to.be.equal(WAD);
-      expect(poolData.startTimestamp).to.be.equal(startTimestamp);
-      expect(poolData.endTimestamp).to.be.equal(endTimestamp);
-      expect(poolData.totalPrincipal).to.be.equal(0);
-    });
-
   });
 
-  context('reset the pool', async () => {
-    beforeEach('revert if a person not admin try reset the pool', async () => {
-      await testEnv.rewardAsset.connect(deployer).faucet();
-      await testEnv.rewardAsset.connect(deployer).approve(testEnv.stakingPool.address, RAY);
-      await testEnv.stakingPool
-        .connect(deployer)
-        .initNewPool(rewardPerSecond, startTimestamp, duration);
-      await resetTimestampTo(startTimestamp);
-    });
+  describe('.revokeManager', async () => {
+    it('is onlyOwner', async () => {
+      await expect(testEnv.stakingPool.connect(depositor).revokeManager(depositor.address))
+        .to.be.revertedWith(
+          'Ownable: caller is not the owner'
+        );
+    })
+  });
 
-    it('revert if a person not admin try extend the pool', async () => {
-      // TODO 
-      /*
-      await expect(
-        testEnv.stakingPool.connect(depositor).extendPool(BigNumber.from(utils.parseEther('2')), BigNumber.from(30).mul(SECONDSPERDAY))
-      ).to.be.revertedWith('OnlyAdmin');
-      */
-    });
-
-    it('success when alice is set up as a manger by admin and', async () => {
+  describe('.setManager', async () => {
+    it('is onlyOwner', async () => {
       await expect(testEnv.stakingPool.connect(depositor).setManager(depositor.address))
         .to.be.revertedWith(
           'Ownable: caller is not the owner'
         );
+    })
+  });
+
+  describe('.extendPool', async () => {
+    beforeEach('init a new pool and jump to the start timestamp', async () => {
+      await actions.faucetAndApproveReward(deployer);
+      await actions.initNewPool(deployer, rewardPerSecond, startTimestamp, duration);
+      await resetTimestampTo(startTimestamp);
+    });
+
+    it('reverts if the message sender is not a manager', async () => {
+      await expect(
+        testEnv.stakingPool.connect(depositor).extendPool(BigNumber.from(utils.parseEther('2')), BigNumber.from(30).mul(SECONDSPERDAY))
+      ).to.be.revertedWith('OnlyManager()');
+    });
+
+    it('succeeds when he/she becomes a manager', async () => {
       await testEnv.stakingPool.connect(deployer).setManager(depositor.address);
       await testEnv.stakingPool.connect(depositor).extendPool(rewardPerSecond, duration);
     });

--- a/test/utils/helpers.ts
+++ b/test/utils/helpers.ts
@@ -1,11 +1,12 @@
+import { MAX_UINT_AMOUNT } from './constants';
 import { BigNumber, Wallet, ethers } from 'ethers';
 import PoolData from '../types/PoolData';
 import TestEnv from '../types/TestEnv';
 import UserData from '../types/UserData';
 
 export type TestHelperActions = {
-  faucetAndApproveTarget: (wallet: Wallet, amount: string) => Promise<void>
-  faucetAndApproveReward: (wallet: Wallet, amount: string) => Promise<void>
+  faucetAndApproveTarget: (wallet: Wallet, amount?: string) => Promise<void>
+  faucetAndApproveReward: (wallet: Wallet, amount?: string) => Promise<void>
   stake: (wallet: Wallet, amount: BigNumber) => Promise<ethers.ContractTransaction>
   withdraw: (wallet: Wallet, amount: BigNumber) => Promise<ethers.ContractTransaction>
   claim: (wallet: Wallet) => Promise<ethers.ContractTransaction>
@@ -26,16 +27,22 @@ export const createTestActions = (testEnv: TestEnv): TestHelperActions => {
   // A target is the token staked.
   const faucetAndApproveTarget = async (
     wallet: Wallet,
-    amount: string,
+    amount?: string,
   ) => {
+    if (amount === undefined) {
+      amount = MAX_UINT_AMOUNT;
+    }
     await testEnv.stakingAsset.connect(wallet).faucet();
     await testEnv.stakingAsset.connect(wallet).approve(testEnv.stakingPool.address, amount);
   }
 
   const faucetAndApproveReward = async (
     wallet: Wallet,
-    amount: string,
+    amount?: string,
   ) => {
+    if (amount === undefined) {
+      amount = MAX_UINT_AMOUNT;
+    }
     await testEnv.rewardAsset.connect(wallet).faucet();
     await testEnv.rewardAsset.connect(wallet).approve(testEnv.stakingPool.address, amount);
   }


### PR DESCRIPTION
### Description
If the staking pool contract inherits both Ownable and AccessControl, we should manage both DEFAULT_ROLE_ADMIN and owner. As we have only one role, 'manager', I suggest not to use openzeppelin AccessControl contract and write the similar logic using the `managers` mapping. 

### Test 
All passes.