### PR TITLE
Fix tests by transferring reward asset

### DIFF
--- a/test/close.test.ts
+++ b/test/close.test.ts
@@ -46,7 +46,7 @@ describe('StakingPool.closePool', () => {
 
   context('when the pool has started', async () => {
     beforeEach(async () => {
-      const tx = await actions.initNewPool(
+      const tx = await actions.initNewPoolAndTransfer(
         deployer, rewardPerSecond, startTimestamp, duration);
       await advanceTimeTo(startTimestamp);
     });

--- a/test/settings.test.ts
+++ b/test/settings.test.ts
@@ -47,7 +47,7 @@ describe('StakingPool.settings', () => {
     expect(await testEnv.stakingPool.rewardAsset()).to.be.equal(testEnv.rewardAsset.address);
   });
 
-  describe('.initNewPool', () => {
+  describe('.initNewPoolAndTransfer', () => {
     context('when the staking pool is deployed', async () => {
       it('reverts if general account initiates the pool', async () => {
         await testEnv.rewardAsset.connect(depositor).faucet();
@@ -104,7 +104,7 @@ describe('StakingPool.settings', () => {
   describe('.extendPool', async () => {
     beforeEach('init a new pool and jump to the start timestamp', async () => {
       await actions.faucetAndApproveReward(deployer);
-      await actions.initNewPool(deployer, rewardPerSecond, startTimestamp, duration);
+      await actions.initNewPoolAndTransfer(deployer, rewardPerSecond, startTimestamp, duration);
       await resetTimestampTo(startTimestamp);
     });
 

--- a/test/stake.test.ts
+++ b/test/stake.test.ts
@@ -57,9 +57,7 @@ describe('StakingPool.stake', () => {
   context('when the pool initiated', async () => {
     context('when the pool has started', async () => {
       beforeEach(async () => {
-        await testEnv.stakingPool
-          .connect(deployer)
-          .initNewPool(rewardPersecond, firstTimestamp, duration);
+        await actions.initNewPoolAndTransfer(deployer, rewardPersecond, firstTimestamp, duration);
         await resetTimestampTo(firstTimestamp);
       });
 
@@ -102,7 +100,7 @@ describe('StakingPool.stake', () => {
         it('revert if open the pool already finished', async () => {
           await actions.closePool(deployer);
           await expect(
-            actions.initNewPool(deployer, rewardPersecond, firstTimestamp, duration)
+            actions.initNewPoolAndTransfer(deployer, rewardPersecond, firstTimestamp, duration)
           ).to.be.revertedWith('Finished');
         });
 
@@ -116,7 +114,7 @@ describe('StakingPool.stake', () => {
 
   context('staking scenario', async () => {
     beforeEach('init the pool and time passes', async () => {
-      await actions.initNewPool(deployer, rewardPersecond, firstTimestamp, duration);
+      await actions.initNewPoolAndTransfer(deployer, rewardPersecond, firstTimestamp, duration);
       actions.faucetAndApproveTarget(bob, RAY);
       await resetTimestampTo(firstTimestamp);
     });
@@ -212,13 +210,10 @@ describe('StakingPool.stake', () => {
 
   context('rewardPerSecond is changed', async () => {
     beforeEach('init the pool and stake in pool', async () => {
-      await testEnv.stakingPool
-        .connect(deployer)
-        .initNewPool(rewardPersecond, firstTimestamp, duration);
+      await actions.initNewPoolAndTransfer(deployer, rewardPersecond, firstTimestamp, duration);
       await testEnv.stakingAsset.connect(alice).approve(testEnv.stakingPool.address, RAY);
       await resetTimestampTo(firstTimestamp);
       await testEnv.stakingPool.connect(alice).stake(stakeAmount);
-      await testEnv.rewardAsset.connect(deployer).transfer(testEnv.stakingPool.address, ethers.utils.parseEther('100'));
     });
 
     it('rewardPerSecond is changed and stake in pool', async () => {
@@ -366,13 +361,12 @@ describe('StakingPool.stake', () => {
     beforeEach('init the pool and alice stakes', async () => {
       await testEnv.rewardAsset.connect(deployer).faucet();
       await testEnv.rewardAsset.connect(deployer).approve(testEnv.stakingPool.address, RAY);
-      await testEnv.stakingPool
-        .connect(deployer)
-        .initNewPool(
-          rewardPersecond,
-          firstTimestamp,
-          duration
-        );
+      await actions.initNewPoolAndTransfer(
+        deployer,
+        rewardPersecond,
+        firstTimestamp,
+        duration
+      );
       await testEnv.stakingAsset.connect(alice).faucet();
       await testEnv.stakingAsset.connect(alice).approve(testEnv.stakingPool.address, RAY);
       await resetTimestampTo(firstTimestamp);

--- a/test/token.test.ts
+++ b/test/token.test.ts
@@ -5,6 +5,7 @@ import { MAX_UINT_AMOUNT, RAY, SECONDSPERDAY, ZERO_ADDRESS } from './utils/const
 import { setTestEnv } from './utils/testEnv';
 import { advanceTimeTo, getTimestamp, toTimestamp } from './utils/time';
 import { buildDelegationData, getSignatureFromTypedData } from './utils/signature';
+import { createTestActions, TestHelperActions } from './utils/helpers';
 
 const { loadFixture } = waffle;
 
@@ -14,6 +15,7 @@ import { expect } from 'chai';
 
 describe('StakingPool.token', () => {
   let testEnv: TestEnv;
+  let actions: TestHelperActions;
   let chainId: number;
 
   const provider = waffle.provider;
@@ -47,6 +49,7 @@ describe('StakingPool.token', () => {
 
   beforeEach('deploy and init staking pool', async () => {
     testEnv = await loadFixture(fixture);
+    actions = createTestActions(testEnv);
   });
 
   context('ERC20', async () => {
@@ -166,9 +169,7 @@ describe('StakingPool.token', () => {
     beforeEach('init the first round and time passes', async () => {
       await testEnv.rewardAsset.connect(deployer).faucet();
       await testEnv.rewardAsset.connect(deployer).approve(testEnv.stakingPool.address, RAY);
-      await testEnv.stakingPool
-        .connect(deployer)
-        .initNewPool(rewardPersecond, startTimestamp, duration);
+      await actions.initNewPoolAndTransfer(deployer, rewardPersecond, startTimestamp, duration);
 
       await testEnv.stakingAsset.connect(alice).faucet();
       await testEnv.stakingAsset.connect(alice).approve(testEnv.stakingPool.address, RAY);


### PR DESCRIPTION
## Problem
I deleted the line of transferring the reward asset in 3b2671c11254a,
which made some tests to fail due to 'ERC20: transfer amount exceeds balance'

## Solution
I added a new helper method `initNewPoolAndTransfer`.

## Test
All passes.