### PR TITLE
Use WAD in index calculation 

### DIFF
--- a/contracts/libraries/StakingPoolLogicV2.sol
+++ b/contracts/libraries/StakingPoolLogicV2.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.4;
 import '../StakingPoolV2.sol';
 import '@openzeppelin/contracts/token/ERC20/IERC20.sol';
 import '@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol';
+import './WadMath.sol';
 
 library StakingPoolLogicV2 {
   using StakingPoolLogicV2 for StakingPoolV2.PoolData;
@@ -29,7 +30,7 @@ library StakingPoolLogicV2 {
       return poolData.rewardIndex;
     }
 
-    uint256 rewardIndexDiff = (timeDiff * poolData.rewardPerSecond * 1e18) / totalPrincipal;
+    uint256 rewardIndexDiff = WadMath.div(timeDiff * poolData.rewardPerSecond, totalPrincipal);
     return poolData.rewardIndex + rewardIndexDiff;
   }
 
@@ -44,7 +45,7 @@ library StakingPoolLogicV2 {
     }
     uint256 indexDiff = getRewardIndex(poolData) - poolData.userIndex[user];
     uint256 balance = poolData.userPrincipal[user];
-    uint256 result = poolData.userReward[user] + (balance * indexDiff) / 1e18;
+    uint256 result = poolData.userReward[user] + WadMath.mul(balance, indexDiff);
     return result;
   }
 

--- a/contracts/libraries/StakingPoolLogicV2.sol
+++ b/contracts/libraries/StakingPoolLogicV2.sol
@@ -29,7 +29,7 @@ library StakingPoolLogicV2 {
       return poolData.rewardIndex;
     }
 
-    uint256 rewardIndexDiff = (timeDiff * poolData.rewardPerSecond * 1e9) / totalPrincipal;
+    uint256 rewardIndexDiff = (timeDiff * poolData.rewardPerSecond * 1e18) / totalPrincipal;
     return poolData.rewardIndex + rewardIndexDiff;
   }
 
@@ -44,7 +44,7 @@ library StakingPoolLogicV2 {
     }
     uint256 indexDiff = getRewardIndex(poolData) - poolData.userIndex[user];
     uint256 balance = poolData.userPrincipal[user];
-    uint256 result = poolData.userReward[user] + (balance * indexDiff) / 1e9;
+    uint256 result = poolData.userReward[user] + (balance * indexDiff) / 1e18;
     return result;
   }
 

--- a/contracts/libraries/WadMath.sol
+++ b/contracts/libraries/WadMath.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.4;
+
+/// @title Math library
+/// @dev Provides mul and div function for wads (decimal numbers with 18 digits precision)
+library WadMath {
+  uint256 internal constant WAD = 1e18;
+  uint256 internal constant halfWAD = WAD / 2;
+
+  /// @dev Multiplies two wad, rounding half up to the nearest wad
+  /// @param a Wad
+  /// @param b Wad
+  /// @return The result of a*b, in wad
+  function mul(uint256 a, uint256 b) internal pure returns (uint256) {
+    if (a == 0 || b == 0) {
+      return 0;
+    }
+    return (a * b + halfWAD) / WAD;
+  }
+
+  /// @dev Divides two wad, rounding half up to the nearest wad
+  /// @param a Wad
+  /// @param b Wad
+  /// @return The result of a/b, in wad
+  function div(uint256 a, uint256 b) internal pure returns (uint256) {
+    require(b != 0, 'Division by Zero');
+    uint256 halfB = b / 2;
+    return (a * WAD + halfB) / b;
+  }
+}

--- a/test/close.test.ts
+++ b/test/close.test.ts
@@ -75,7 +75,7 @@ describe('StakingPool.closePool', () => {
 
       // After a user claims, userIndex changes, but the rewardIndex remains the same.
       expect(aliceDataAfterClaim.userReward).to.equal(utils.parseEther('0'));
-      expect(aliceDataAfterClaim.userIndex).to.equal(BigNumber.from('1000000010000000000'));
+      expect(aliceDataAfterClaim.userIndex).to.equal(utils.parseEther('11'));
 
       expect(poolDataAfterClaim.rewardIndex).to.equal(initialIndex);
     });

--- a/test/utils/calculate.ts
+++ b/test/utils/calculate.ts
@@ -1,6 +1,7 @@
-import { BigNumber } from 'ethers';
+import { BigNumber, constants } from 'ethers';
 import PoolData from '../types/PoolData';
 import UserData from '../types/UserData';
+import { WAD } from '../utils/constants';
 
 export function calculateRewardIndex(poolData: PoolData, txTimeStamp: BigNumber): BigNumber {
   const currentTimestamp = txTimeStamp.lt(poolData.endTimestamp)
@@ -19,7 +20,7 @@ export function calculateRewardIndex(poolData: PoolData, txTimeStamp: BigNumber)
 
   const rewardIndexDiff = timeDiff
     .mul(poolData.rewardPerSecond)
-    .mul(1e9)
+    .mul(WAD)
     .div(poolData.totalPrincipal);
 
   return poolData.rewardIndex.add(rewardIndexDiff);
@@ -36,7 +37,7 @@ export function calculateUserReward(
 
   const indexDiff = calculateRewardIndex(poolData, txTimeStamp).sub(userData.userIndex);
   const balance = userData.userPrincipal;
-  const rewardAdded = balance.mul(indexDiff).div(1e9);
+  const rewardAdded = balance.mul(indexDiff).div(WAD);
   const result = userData.userPreviousReward.add(rewardAdded);
 
   return result;

--- a/test/utils/calculate.ts
+++ b/test/utils/calculate.ts
@@ -2,6 +2,7 @@ import { BigNumber, constants } from 'ethers';
 import PoolData from '../types/PoolData';
 import UserData from '../types/UserData';
 import { WAD } from '../utils/constants';
+import { wadMul, wadDiv } from '../utils/math';
 
 export function calculateRewardIndex(poolData: PoolData, txTimeStamp: BigNumber): BigNumber {
   const currentTimestamp = txTimeStamp.lt(poolData.endTimestamp)
@@ -18,10 +19,10 @@ export function calculateRewardIndex(poolData: PoolData, txTimeStamp: BigNumber)
     return poolData.rewardIndex;
   }
 
-  const rewardIndexDiff = timeDiff
-    .mul(poolData.rewardPerSecond)
-    .mul(WAD)
-    .div(poolData.totalPrincipal);
+  const rewardIndexDiff = wadDiv(
+    timeDiff.mul(poolData.rewardPerSecond),
+    poolData.totalPrincipal
+  );
 
   return poolData.rewardIndex.add(rewardIndexDiff);
 }
@@ -37,7 +38,7 @@ export function calculateUserReward(
 
   const indexDiff = calculateRewardIndex(poolData, txTimeStamp).sub(userData.userIndex);
   const balance = userData.userPrincipal;
-  const rewardAdded = balance.mul(indexDiff).div(WAD);
+  const rewardAdded = wadMul(balance, indexDiff);
   const result = userData.userPreviousReward.add(rewardAdded);
 
   return result;

--- a/test/utils/math.ts
+++ b/test/utils/math.ts
@@ -1,0 +1,15 @@
+import { BigNumber } from 'ethers';
+import { WAD } from './constants';
+
+export function wadMul(m: BigNumber, n: BigNumber): BigNumber {
+  const halfWad = BigNumber.from(WAD).div(2);
+
+  return m.mul(n).add(halfWad).div(WAD);
+}
+
+export function wadDiv(m: BigNumber, n: BigNumber): BigNumber {
+  const half = n.div(2);
+
+  return half.add(m.mul(WAD)).div(n);
+}
+


### PR DESCRIPTION
## Problem
It is confusing that `rewardIndex`, and `userIndex` are initialized in
18 decimals, but their increments actually have 9 decimals.
This is due to the calculation below. 
```solidity
// decimal: 18 + 9 - 18 = 9
uint256 rewardIndexDiff = (timeDiff * poolData.rewardPerSecond * 1e9) / totalPrincipal;
```

## Solution
Make every index calcuation to have 18 decimals.

## Test 
All passes.