### PR TITLE
Extract Manageable contract

### DIFF
--- a/contracts/Manageable.sol
+++ b/contracts/Manageable.sol
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.4;
+
+import './interface/IManageable.sol';
+import '@openzeppelin/contracts/access/Ownable.sol';
+
+/// @dev An owner is able to change the managers.
+contract Manageable is IManageable, Ownable {
+  mapping(address => bool) managers;
+
+  function setManager(address addr) external onlyOwner {
+    _setManager(addr);
+  }
+
+  function revokeManager(address addr) external onlyOwner {
+    _revokeManager(addr);
+  }
+
+  function renounceManager(address addr) external {
+    require(addr == msg.sender, "Can only renounce manager for self");
+    _revokeManager(addr);
+  }
+
+  function isManager(address addr) public view returns (bool) {
+    return managers[addr] || addr == owner();
+  }
+
+  /***************** private ******************/
+  function _setManager(address addr) private {
+    if (!isManager(addr)) {
+      managers[addr] = true;
+      emit SetManager(msg.sender, addr);
+    }
+  }
+
+  function _revokeManager(address addr) private {
+    if (isManager(addr)) {
+      managers[addr] = false;
+      emit RevokeManager(msg.sender, addr);
+    }
+  }
+
+  /***************** Modifier ******************/
+  modifier onlyManager() {
+    if (!isManager(msg.sender)) revert OnlyManager();
+    _;
+  }
+}

--- a/contracts/interface/IManageable.sol
+++ b/contracts/interface/IManageable.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.4;
+interface IManageable {
+  error OnlyManager();
+  event SetManager(address admin, address manager);
+
+  /// @param requester owner or the manager himself/herself
+  event RevokeManager(address requester, address manager);
+}

--- a/contracts/interface/IStakingPoolV2.sol
+++ b/contracts/interface/IStakingPoolV2.sol
@@ -5,7 +5,6 @@ interface IStakingPoolV2 {
   error StakingNotInitiated();
   error InvalidAmount();
   error ZeroReward();
-  error OnlyManager();
   error NotEnoughPrincipal(uint256 principal);
   error ZeroPrincipal();
   error Finished();
@@ -43,11 +42,6 @@ interface IStakingPoolV2 {
   event ClosePool(address admin, bool close);
 
   event RetrieveResidue(address manager, uint256 residueAmount);
-
-  event SetManager(address admin, address manager);
-
-  /// @param requester owner or the manager himself/herself
-  event RevokeManager(address requester, address manager);
 
   event SetEmergency(address admin, bool emergency);
 


### PR DESCRIPTION
## Problem
Openzeppelin `AccessControl` contract cannot maintain a single admin who can update the list of managers. It uses a role admin and role admins of `managers` can be many.

## Solution
`Manageable` inherits `Ownable` and the owner can appoint and revoke managers.
- One owner
- Multiple managers